### PR TITLE
docs: add crypto to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
 
 - [Connection](./src/connection)
 - [Content Routing](./src/content-routing)
+- [Crypto](./src/crypto)
 - [Peer Discovery](./src/peer-discovery)
 - [Peer Routing](./src/peer-routing)
 - [Stream Muxer](./src/stream-muxer)


### PR DESCRIPTION
Crypto interface was missing in the README