### PR TITLE
fix: localAddr should be optional

### DIFF
--- a/src/connection/README.md
+++ b/src/connection/README.md
@@ -109,7 +109,7 @@ const conn = new Connection({
 
 Creates a new Connection instance.
 
-`localAddr` is the [multiaddr](https://github.com/multiformats/multiaddr) address used by the local peer to reach the remote.
+`localAddr` is the optional [multiaddr](https://github.com/multiformats/multiaddr) address used by the local peer to reach the remote.
 `remoteAddr` is the [multiaddr](https://github.com/multiformats/multiaddr) address used to communicate with the remote peer.
 `localPeer` is the [PeerId](https://github.com/libp2p/js-peer-id) of the local peer.
 `remotePeer` is the [PeerId](https://github.com/libp2p/js-peer-id) of the remote peer.

--- a/src/connection/connection.js
+++ b/src/connection/connection.js
@@ -16,7 +16,7 @@ class Connection {
   /**
    * Creates an instance of Connection.
    * @param {object} properties properties of the connection.
-   * @param {multiaddr} properties.localAddr local multiaddr of the connection.
+   * @param {multiaddr} [properties.localAddr] local multiaddr of the connection if known.
    * @param {multiaddr} properties.remoteAddr remote multiaddr of the connection.
    * @param {PeerId} properties.localPeer local peer-id.
    * @param {PeerId} properties.remotePeer remote peer-id.
@@ -32,7 +32,7 @@ class Connection {
    * @param {string} [properties.stat.encryption] connection encryption method identifier.
    */
   constructor ({ localAddr, remoteAddr, localPeer, remotePeer, newStream, close, getStreams, stat }) {
-    assert(multiaddr.isMultiaddr(localAddr), 'localAddr must be an instance of multiaddr')
+    localAddr && assert(multiaddr.isMultiaddr(localAddr), 'localAddr must be an instance of multiaddr')
     assert(multiaddr.isMultiaddr(remoteAddr), 'remoteAddr must be an instance of multiaddr')
     assert(PeerId.isPeerId(localPeer), 'localPeer must be an instance of peer-id')
     assert(PeerId.isPeerId(remotePeer), 'remotePeer must be an instance of peer-id')


### PR DESCRIPTION
The local address of a connection will not always be known, such as a browser client, so it should not be required.