### PR TITLE
feat: add class-is to topology

### DIFF
--- a/src/topology/index.js
+++ b/src/topology/index.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const withIs = require('class-is')
+
 const noop = () => {}
 
 class Topology {
@@ -41,4 +43,4 @@ class Topology {
   }
 }
 
-module.exports = Topology
+module.exports = withIs(Topology, { className: 'Topology', symbolName: '@libp2p/js-interfaces/topology' })

--- a/src/topology/multicodec-topology.js
+++ b/src/topology/multicodec-topology.js
@@ -1,6 +1,8 @@
 'use strict'
 
 const assert = require('assert')
+const withIs = require('class-is')
+
 const Topology = require('./index')
 
 class MulticodecTopology extends Topology {
@@ -90,4 +92,4 @@ class MulticodecTopology extends Topology {
   }
 }
 
-module.exports = MulticodecTopology
+module.exports = withIs(MulticodecTopology, { className: 'MulticodecTopology', symbolName: '@libp2p/js-interfaces/topology/multicodec-topology' })


### PR DESCRIPTION
Add `class-is` to topology, in order to allow registrar to validate the parameter