### PR TITLE
fix: multicodec topology disconnect with peer param

### DIFF
--- a/src/topology/multicodec-topology.js
+++ b/src/topology/multicodec-topology.js
@@ -77,9 +77,7 @@ class MulticodecTopology extends Topology {
 
     // Not supporting the protocol anymore?
     if (existingPeer && hasProtocol.length === 0) {
-      this._onDisconnect({
-        peerInfo
-      })
+      this._onDisconnect(peerInfo)
     }
 
     // New to protocol support

--- a/src/topology/tests/multicodec-topology.js
+++ b/src/topology/tests/multicodec-topology.js
@@ -86,6 +86,7 @@ module.exports = (test) => {
 
       expect(topology.peers.size).to.eql(1)
       expect(topology._onDisconnect.callCount).to.equal(1)
+      expect(topology._onDisconnect.calledWith(peer2)).to.equal(true)
     })
   })
 }


### PR DESCRIPTION
As specified in the [readme](https://github.com/libp2p/js-interfaces/blob/master/src/topology/README.md#multicodec-topology-1) and used in [js-libp2p-pubsub](https://github.com/libp2p/js-libp2p-pubsub/blob/master/src/index.js#L186), as well as to be consistent with `onConnect`, the parameters should not be an object but a single parameter with the `peerInfo`