### PR TITLE
feat: export connection status'

### DIFF
--- a/src/connection/README.md
+++ b/src/connection/README.md
@@ -121,7 +121,7 @@ Creates a new Connection instance.
 - `timeline` is an `object` with the relevant events timestamps of the connection (`open`, `upgraded` and `closed`; the `closed` will be added when the connection is closed).
 - `multiplexer` is a `string` with the connection multiplexing codec (optional).
 - `encryption` is a `string` with the connection encryption method identifier (optional).
-- `status` is a `string` indicating the overall status of the connection. It is one of [`'closed'`, `'closing'`, `'closed'`]
+- `status` is a `string` indicating the overall status of the connection. It is one of [`'open'`, `'closing'`, `'closed'`]
 
 #### Create a new stream
 

--- a/src/connection/README.md
+++ b/src/connection/README.md
@@ -121,6 +121,7 @@ Creates a new Connection instance.
 - `timeline` is an `object` with the relevant events timestamps of the connection (`open`, `upgraded` and `closed`; the `closed` will be added when the connection is closed).
 - `multiplexer` is a `string` with the connection multiplexing codec (optional).
 - `encryption` is a `string` with the connection encryption method identifier (optional).
+- `status` is a `string` indicating the overall status of the connection. It is one of [`'closed'`, `'closing'`, `'closed'`]
 
 #### Create a new stream
 
@@ -220,7 +221,17 @@ This getter returns an `Object` with the metadata of the connection, as follows:
 
 - `status`:
 
-This property contains the status of the connection. It can be either `open`, `closing` or `closed`. Once the connection is created it is in an `open` status. When a `conn.close()` happens, the status will change to `closing` and finally, after all the connection streams are properly closed, the status will be `closed`.
+This property contains the status of the connection. It can be either `open`, `closing` or `closed`. Once the connection is created it is in an `open` status. When a `conn.close()` happens, the status will change to `closing` and finally, after all the connection streams are properly closed, the status will be `closed`. These values can also be directly referenced by importing the `status` file:
+
+```js
+const {
+  OPEN, CLOSING, CLOSED
+} = require('libp2p-interfaces/src/connection/status')
+
+if (connection.stat.status === OPEN) {
+  // ...
+}
+```
 
 - `timeline`:
 

--- a/src/connection/connection.js
+++ b/src/connection/connection.js
@@ -7,6 +7,7 @@ const withIs = require('class-is')
 
 const assert = require('assert')
 const errCode = require('err-code')
+const Status = require('./status')
 
 /**
  * An implementation of the js-libp2p connection.
@@ -75,7 +76,7 @@ class Connection {
      */
     this._stat = {
       ...stat,
-      status: 'open'
+      status: Status.OPEN
     }
 
     /**
@@ -126,11 +127,11 @@ class Connection {
    * @return {Promise<object>} with muxed+multistream-selected stream and selected protocol
    */
   async newStream (protocols) {
-    if (this.stat.status === 'closing') {
+    if (this.stat.status === Status.CLOSING) {
       throw errCode(new Error('the connection is being closed'), 'ERR_CONNECTION_BEING_CLOSED')
     }
 
-    if (this.stat.status === 'closed') {
+    if (this.stat.status === Status.CLOSED) {
       throw errCode(new Error('the connection is closed'), 'ERR_CONNECTION_CLOSED')
     }
 
@@ -175,7 +176,7 @@ class Connection {
    * @return {Promise}
    */
   async close () {
-    if (this.stat.status === 'closed') {
+    if (this.stat.status === Status.CLOSED) {
       return
     }
 
@@ -183,13 +184,13 @@ class Connection {
       return this._closing
     }
 
-    this.stat.status = 'closing'
+    this.stat.status = Status.CLOSING
 
     // Close raw connection
     this._closing = await this._close()
 
     this._stat.timeline.close = Date.now()
-    this.stat.status = 'closed'
+    this.stat.status = Status.CLOSED
   }
 }
 

--- a/src/connection/status.js
+++ b/src/connection/status.js
@@ -1,0 +1,7 @@
+'use strict'
+
+module.exports = {
+  OPEN: 'open',
+  CLOSING: 'closing',
+  CLOSED: 'closed'
+}

--- a/src/connection/tests/connection.js
+++ b/src/connection/tests/connection.js
@@ -6,6 +6,7 @@ const chai = require('chai')
 const expect = chai.expect
 chai.use(require('dirty-chai'))
 const sinon = require('sinon')
+const Status = require('../status')
 
 module.exports = (test) => {
   describe('connection', () => {
@@ -28,7 +29,7 @@ module.exports = (test) => {
         expect(connection.remotePeer).to.exist()
         expect(connection.localAddr).to.exist()
         expect(connection.remoteAddr).to.exist()
-        expect(connection.stat.status).to.equal('open')
+        expect(connection.stat.status).to.equal(Status.OPEN)
         expect(connection.stat.timeline.open).to.exist()
         expect(connection.stat.timeline.upgraded).to.exist()
         expect(connection.stat.timeline.close).to.not.exist()
@@ -40,7 +41,7 @@ module.exports = (test) => {
       it('should get the metadata of an open connection', () => {
         const stat = connection.stat
 
-        expect(stat.status).to.equal('open')
+        expect(stat.status).to.equal(Status.OPEN)
         expect(stat.direction).to.exist()
         expect(stat.timeline.open).to.exist()
         expect(stat.timeline.upgraded).to.exist()
@@ -103,7 +104,7 @@ module.exports = (test) => {
         await connection.close()
 
         expect(connection.stat.timeline.close).to.exist()
-        expect(connection.stat.status).to.equal('closed')
+        expect(connection.stat.status).to.equal(Status.CLOSED)
       })
 
       it('should be able to close the connection after opening a stream', async () => {
@@ -116,7 +117,7 @@ module.exports = (test) => {
         await connection.close()
 
         expect(connection.stat.timeline.close).to.exist()
-        expect(connection.stat.status).to.equal('closed')
+        expect(connection.stat.status).to.equal(Status.CLOSED)
       })
 
       it('should support a proxy on the timeline', async () => {


### PR DESCRIPTION
This exports the Connection status' and uses them internally, so they can be more consistently used by other libraries.