### PR TITLE
fix: transport should not handle connection if upgradeInbound throws

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "libp2p-tcp": "^0.14.1",
     "multiaddr": "^7.1.0",
     "p-limit": "^2.2.1",
+    "p-wait-for": "^3.1.0",
     "peer-id": "^0.13.3",
     "sinon": "^7.5.0",
     "streaming-iterables": "^4.1.0"

--- a/src/transport/tests/listen-test.js
+++ b/src/transport/tests/listen-test.js
@@ -8,6 +8,7 @@ const expect = chai.expect
 chai.use(dirtyChai)
 const sinon = require('sinon')
 
+const pWaitFor = require('p-wait-for')
 const pipe = require('it-pipe')
 const { isValidTick } = require('./utils')
 
@@ -105,7 +106,7 @@ module.exports = (common) => {
       // Create a connection to the listener
       const socket = await transport.dial(addrs[0])
 
-      await socket.close()
+      await pWaitFor(() => typeof socket.timeline.close === 'number')
       await listener.close()
     })
 

--- a/src/transport/tests/listen-test.js
+++ b/src/transport/tests/listen-test.js
@@ -92,6 +92,23 @@ module.exports = (common) => {
       expect(upgradeSpy.callCount).to.equal(2)
     })
 
+    it('should not handle connection if upgradeInbound throws', async () => {
+      sinon.stub(upgrader, 'upgradeInbound').throws()
+
+      const listener = transport.createListener(() => {
+        throw new Error('should not handle the connection if upgradeInbound throws')
+      })
+
+      // Listen
+      await listener.listen(addrs[0])
+
+      // Create a connection to the listener
+      const socket = await transport.dial(addrs[0])
+
+      await socket.close()
+      await listener.close()
+    })
+
     describe('events', () => {
       it('connection', (done) => {
         const upgradeSpy = sinon.spy(upgrader, 'upgradeInbound')


### PR DESCRIPTION
Fixed per discussion on [libp2p/js-libp2p#523#discussion_r359997872](https://github.com/libp2p/js-libp2p/pull/523#discussion_r359997872)