### PR TITLE
fix: dependencies for tests should not be needed by who requires the tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,8 @@
     "dirty-chai": "^2.0.1",
     "err-code": "^2.0.0",
     "it-goodbye": "^2.0.1",
+    "it-pair": "^1.0.0",
+    "it-pipe": "^1.0.1",
     "libp2p-tcp": "^0.14.1",
     "multiaddr": "^7.1.0",
     "p-limit": "^2.2.1",
@@ -54,8 +56,6 @@
   "devDependencies": {
     "aegir": "^20.4.1",
     "it-handshake": "^1.0.0",
-    "it-pair": "^1.0.0",
-    "it-pipe": "^1.0.1",
     "peer-info": "^0.17.0"
   },
   "contributors": [

--- a/package.json
+++ b/package.json
@@ -47,16 +47,16 @@
     "it-pipe": "^1.0.1",
     "libp2p-tcp": "^0.14.1",
     "multiaddr": "^7.1.0",
-    "p-limit": "^2.2.1",
+    "p-limit": "^2.2.2",
     "p-wait-for": "^3.1.0",
     "peer-id": "^0.13.3",
+    "peer-info": "^0.17.0",
     "sinon": "^7.5.0",
     "streaming-iterables": "^4.1.0"
   },
   "devDependencies": {
-    "aegir": "^20.4.1",
-    "it-handshake": "^1.0.0",
-    "peer-info": "^0.17.0"
+    "aegir": "^20.5.0",
+    "it-handshake": "^1.0.1"
   },
   "contributors": [
     "Alan Shaw <alan.shaw@protocol.ai>",


### PR DESCRIPTION
Currently, transports must have `it-pipe` and `it-pair` in their dependencies, otherwise they are not able to run the interface tests