### PR TITLE
fix(connection): dont require remoteAddr on creation

### DIFF
--- a/src/connection/README.md
+++ b/src/connection/README.md
@@ -110,7 +110,7 @@ const conn = new Connection({
 Creates a new Connection instance.
 
 `localAddr` is the optional [multiaddr](https://github.com/multiformats/multiaddr) address used by the local peer to reach the remote.
-`remoteAddr` is the [multiaddr](https://github.com/multiformats/multiaddr) address used to communicate with the remote peer.
+`remoteAddr` is the optional [multiaddr](https://github.com/multiformats/multiaddr) address used to communicate with the remote peer.
 `localPeer` is the [PeerId](https://github.com/libp2p/js-peer-id) of the local peer.
 `remotePeer` is the [PeerId](https://github.com/libp2p/js-peer-id) of the remote peer.
 `newStream` is the `function` responsible for getting a new muxed+multistream-selected stream.

--- a/src/connection/connection.js
+++ b/src/connection/connection.js
@@ -18,7 +18,7 @@ class Connection {
    * Creates an instance of Connection.
    * @param {object} properties properties of the connection.
    * @param {multiaddr} [properties.localAddr] local multiaddr of the connection if known.
-   * @param {multiaddr} properties.remoteAddr remote multiaddr of the connection.
+   * @param {multiaddr} [properties.remoteAddr] remote multiaddr of the connection.
    * @param {PeerId} properties.localPeer local peer-id.
    * @param {PeerId} properties.remotePeer remote peer-id.
    * @param {function} properties.newStream new stream muxer function.
@@ -34,7 +34,6 @@ class Connection {
    */
   constructor ({ localAddr, remoteAddr, localPeer, remotePeer, newStream, close, getStreams, stat }) {
     localAddr && assert(multiaddr.isMultiaddr(localAddr), 'localAddr must be an instance of multiaddr')
-    assert(multiaddr.isMultiaddr(remoteAddr), 'remoteAddr must be an instance of multiaddr')
     assert(PeerId.isPeerId(localPeer), 'localPeer must be an instance of peer-id')
     assert(PeerId.isPeerId(remotePeer), 'remotePeer must be an instance of peer-id')
     assert(typeof newStream === 'function', 'new stream must be a function')

--- a/test/connection/index.spec.js
+++ b/test/connection/index.spec.js
@@ -1,0 +1,48 @@
+/* eslint-env mocha */
+'use strict'
+
+const { Connection } = require('../../src/connection')
+const peers = require('../../src/utils/peers')
+const PeerId = require('peer-id')
+const pair = require('it-pair')
+
+describe('connection tests', () => {
+  it('should not require local or remote addrs', async () => {
+    const [localPeer, remotePeer] = await Promise.all([
+      PeerId.createFromJSON(peers[0]),
+      PeerId.createFromJSON(peers[1])
+    ])
+    const openStreams = []
+    let streamId = 0
+
+    return new Connection({
+      localPeer,
+      remotePeer,
+      stat: {
+        timeline: {
+          open: Date.now() - 10,
+          upgraded: Date.now()
+        },
+        direction: 'outbound',
+        encryption: '/secio/1.0.0',
+        multiplexer: '/mplex/6.7.0'
+      },
+      newStream: (protocols) => {
+        const id = streamId++
+        const stream = pair()
+
+        stream.close = () => stream.sink([])
+        stream.id = id
+
+        openStreams.push(stream)
+
+        return {
+          stream,
+          protocol: protocols[0]
+        }
+      },
+      close: () => {},
+      getStreams: () => openStreams
+    })
+  })
+})


### PR DESCRIPTION
Not every transport is going to know the remote address of a new connection when it is created, such as a WebRTC connection in browser. While we can eventually determine an observed address, requiring it at Connection creation is not reasonable.

Using webrtc as an example, there is no valid remote address for a peer we received an incoming address from. A valid multiaddr for the peer would be the signaling server we connected through, plus the id of the peer. We don't know the id of the remote peer until Crypto runs during the upgrade process. In theory, we could assemble the remoteAddress before Connection creation, but it requires context of the Transport dialing it. Rather than coding for n number of transports in the libp2p dialer, it would be better to create the upgraded connection and then hand that back to the Transport, at which point the Transport could set the remoteAddr, if it was not already set.