### PR TITLE
fix(transport): make close listener test more resilient

### DIFF
--- a/src/transport/tests/listen-test.js
+++ b/src/transport/tests/listen-test.js
@@ -70,7 +70,7 @@ module.exports = (common) => {
       ])
 
       // Give the listener a chance to finish its upgrade
-      await new Promise(resolve => setTimeout(resolve, 0))
+      await pWaitFor(() => listenerConns.length === 2)
 
       // Wait for the data send and close to finish
       await Promise.all([


### PR DESCRIPTION
This makes the listener test a bit more resilient by waiting for both listener side connections to be fully established before executing the close. The current setTimeout of 0 isn't sufficient for slower connection establishment (like webrtc signaling).