### PR TITLE
fix(connection): tracks streams properly

### DIFF
--- a/src/connection/connection.js
+++ b/src/connection/connection.js
@@ -138,7 +138,7 @@ class Connection {
 
     const { stream, protocol } = await this._newStream(protocols)
 
-    this.addStream(stream, protocol)
+    this.addStream(stream, { protocol })
 
     return {
       stream,

--- a/src/connection/tests/connection.js
+++ b/src/connection/tests/connection.js
@@ -120,6 +120,19 @@ module.exports = (test) => {
         expect(connection.stat.status).to.equal(Status.CLOSED)
       })
 
+      it('should properly track streams', async () => {
+        // Open stream
+        const protocol = '/echo/0.0.1'
+        const { stream } = await connection.newStream(protocol)
+        const trackedStream = connection.registry.get(stream.id)
+        expect(trackedStream).to.have.property('protocol', protocol)
+
+        // Close stream
+        await stream.close()
+
+        expect(connection.registry.get(stream.id)).to.not.exist()
+      })
+
       it('should support a proxy on the timeline', async () => {
         sinon.spy(proxyHandler, 'set')
         expect(connection.stat.timeline.close).to.not.exist()

--- a/test/connection/compliance.spec.js
+++ b/test/connection/compliance.spec.js
@@ -25,7 +25,7 @@ describe('compliance tests', () => {
       const openStreams = []
       let streamId = 0
 
-      return new Connection({
+      const connection = new Connection({
         localPeer,
         remotePeer,
         localAddr,
@@ -43,7 +43,10 @@ describe('compliance tests', () => {
           const id = streamId++
           const stream = pair()
 
-          stream.close = () => stream.sink([])
+          stream.close = async () => {
+            await stream.sink([])
+            connection.removeStream(stream.id)
+          }
           stream.id = id
 
           openStreams.push(stream)
@@ -57,6 +60,7 @@ describe('compliance tests', () => {
         getStreams: () => openStreams,
         ...properties
       })
+      return connection
     },
     async teardown () {
       // cleanup resources created by setup()


### PR DESCRIPTION
`connection.addStream` was not being properly called internally. This would cause stream protocols to not be tracked properly. This also adds a test to the interface to ensure connection implementations are properly removing streams from tracking when `stream.close()` is called.